### PR TITLE
improve firebase credential setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,20 @@
-# Copy and rename this file to .env
+# Diese Datei muss kopiert und umbenannt werden in '.env'
+# Dort werden Variablen gespeichert, die entweder geheim sind,
+# oder sich je nach Umgebung unterscheiden können (Development vs Production)
+
+# Die WEBSITE_URL zeigt zur API der Website AG.
+# Von dort fragen wir regelmäßig Ortsgruppen- und Streikdaten ab.
+#
 WEBSITE_URL=https://api.fffutu.re/v1
+
+# Wir verwenden Firebase, um Push-Benachrichtigungen zu versenden.
+# Für die lokale Entwicklungsumgebung ist dies nicht zwingend erforderlich.
+#
+# FIREBASE_URL=https://de-fridaysforfuture-app.firebaseio.com
+
+# Die GOOGLE_APPLICATION_CREDENTIALS verweisen auf eine JSON-Datei,
+# welche zur Authentifizierung bei Firebase dient.
+# Die Datei ist für die lokale Entwicklungsumgebung nicht zwingend erforderlich.
+# Weitere Infos unter https://firebase.google.com/docs/admin/setup/#initialize-sdk
+#
+# GOOGLE_APPLICATION_CREDENTIALS=src/auth/de-fridaysforfuture-app-firebase-adminsdk-98yw1-c45342f3dc.json

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,9 +14,7 @@ const CronJob = require("cron").CronJob;
 let mongoUp = true;
 
 //------FCM------
-export const messageAdmin = new FCMAdmin(
-  "../src/auth/de-fridaysforfuture-app-firebase-adminsdk-98yw1-c45342f3dc.json"
-);
+export const messageAdmin = new FCMAdmin();
 
 //------DoS-Protection------
 const DoSProtection = new Ddos({ burst: 10, limit: 15 }); //probably need to adjust these

--- a/src/fcm.ts
+++ b/src/fcm.ts
@@ -1,22 +1,22 @@
 import * as admin from "firebase-admin";
 export default class FCMAdmin {
-  private authPath: string;
   private firebaseReady: boolean;
 
-  constructor(ap: string) {
-    this.authPath = ap;
+  constructor() {
     // Authentification
     try {
-      const serviceAccount = require(this.authPath);
+      if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+        throw "Warning: Connection to firebase could not be established. No credentials provided";
+      }
+
       admin.initializeApp({
-        credential: admin.credential.cert(serviceAccount),
-        databaseURL: "https://de-fridaysforfuture-app.firebaseio.com"
+        credential: admin.credential.applicationDefault(),
+        databaseURL: process.env.FIREBASE_URL
       });
       this.firebaseReady = true;
+      console.log("Successfully established connection to firebase.");
     } catch (error) {
-      console.log(
-        "Connection to firebase could not be established. Maybe the firebase credential file is missing."
-      );
+      console.log(error);
       this.firebaseReady = false;
     }
   }


### PR DESCRIPTION
to remove lint error "Require statement not part of import statement  @typescript-eslint/no-var-requires"

der dateiname steht jetzt im .env file und wird bei startup der applikation geladen.
falls kein pfad angegeben, oder keine datei vorhanden, dann schlägt die verbindung fehl und es wird eine fehler- bzw. warnmeldung auf der konsole ausgegeben, ohne dass der server crasht.