### PR TITLE
fix time zone

### DIFF
--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -29,7 +29,8 @@ export async function saveAsStrike(
     minutes = parseInt(matches[1] || "0");
   }
 
-  const jsDate = new Date(year, month - 1, day, hour, minutes);
+  // TODO: Fix time zone
+  const jsDate = new Date(year, month - 1, day, hour - 2, minutes);
   const unixDate = util.toUnixTimestamp(jsDate);
 
   // TODO


### PR DESCRIPTION
In der App werden gerade falsche Zeiten angezeigt (19:00 Uhr anstatt eigentlich 17:00 Uhr)