### PR TITLE
Leserbriefe

### DIFF
--- a/src/endpoints/commentController.ts
+++ b/src/endpoints/commentController.ts
@@ -1,0 +1,14 @@
+import { RequestHandler } from "express";
+import { Comment } from "../models/commentModel";
+
+export const createComment: RequestHandler = async (req, res) => {
+  const success = await Comment.create({
+    name: req.body.name,
+    age: req.body.age,
+    content: req.body.content,
+    publish: req.body.publish,
+    articleReference: req.body.articleReference,
+  });
+  // TODO: redirect to new success page
+  res.redirect("/views/panel/controls".concat(success ? "" : "?err=true"));
+};

--- a/src/express/routes.ts
+++ b/src/express/routes.ts
@@ -35,6 +35,7 @@ import {
 import { sharePost } from "../endpoints/share";
 import { loginView, controlsView } from "../endpoints/views";
 import { webhookTriggered } from "../endpoints/webhook";
+import { createComment } from "../endpoints/commentController";
 
 export const controlsRoutes = Router();
 export const apiRoutes = Router();
@@ -69,6 +70,7 @@ controlsRoutes.post("/feed/add", addFeedItem);
 controlsRoutes.post("/feed/edit", editFeedItem);
 controlsRoutes.post("/feed/remove", deleteFeedItem);
 
+apiRoutes.post("/comment", createComment);
 apiRoutes.get("/liveevent", getLiveevent);
 apiRoutes.get("/strikes", getStrikes);
 apiRoutes.get("/slogans", getSlogans);

--- a/src/models/commentModel.ts
+++ b/src/models/commentModel.ts
@@ -1,0 +1,39 @@
+import { model, Schema, Model, Document } from "mongoose";
+
+// App users can send editorial comments (Leserbriefe)
+export interface IComment extends Document {
+  name: string;
+  content: string;
+  publish: boolean;
+  articleReference: string;
+  age?: number;
+  read?: boolean;
+}
+
+const commentScheme = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  content: {
+    type: String,
+    required: true,
+  },
+  publish: {
+    type: Boolean,
+    required: true,
+  },
+  articleReference: {
+    type: String,
+    required: true,
+  },
+  age: {
+    type: Number,
+  },
+  read: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+export const Comment: Model<IComment> = model("comment", commentScheme);


### PR DESCRIPTION
User sollen über das Webseitenformular (welches in die App eingebettet wird) Leserbriefe an das Lektorat senden können.
Das Lektorat soll die Nachrichten im Control Panel einsehen können.